### PR TITLE
Update SSO demo, remove deprecated method usage.

### DIFF
--- a/demo/sso/index.html
+++ b/demo/sso/index.html
@@ -57,14 +57,14 @@
 <script type="text/javascript">
 
     var REDIRECT_URI = decodeURIComponent(window.location.href.split('sso', 1) + 'sso/redirect.html'),
-            rcsdk = new RingCentral.sdk.SDK({
-                server: localStorage.getItem('ringcentral-demo-server') || RingCentral.server.sandbox,
+            rcsdk = new RingCentral.SDK({
+                server: localStorage.getItem('ringcentral-demo-server') || RingCentral.SDK.server.sandbox,
                 appKey: localStorage.getItem('ringcentral-demo-appKey'),
                 appSecret: localStorage.getItem('ringcentral-demo-appSecret')
             }),
-            platform = rcsdk.getPlatform();
+            platform = rcsdk.platform();
 
-    if (!platform.getAppCredentials().appKey || !platform.getAppCredentials().appKey || !platform.getServer()) {
+    if (!platform._appSecret || !platform._appKey || !platform._server) {
         location.assign('../apiKey.html');
     }
 
@@ -84,7 +84,7 @@
             console.log('About to authorize with the following stuff', qs);
 
             platform
-                    .authorize(qs)
+                    .login(qs)
                     .then(function(res) {
                         console.log('Auth response', res.json);
                         alert('Auth success, demo ends here');
@@ -101,7 +101,7 @@
 
     function openSSO() {
 
-        var url = platform.getAuthURL({
+        var url = platform.authUrl({
             redirectUri: REDIRECT_URI,
             prompt: 'login sso',
             display: 'touch'


### PR DESCRIPTION
Hello, the SSO demo cannot work due to some deprecated methods. I correct them use the latest SDK version.
