### PR TITLE
Batch request via PUT

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -163,3 +163,15 @@ export function delay(timeout) {
         }, timeout);
     });
 }
+
+/**
+ * TODO Replace with something better
+ * @see http://stackoverflow.com/users/109538/broofa
+ * @returns {string}
+ */
+export function uuid() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random()*16|0, v = c === 'x' ? r : (r&0x3|0x8);
+    return v.toString(16);
+  });
+}

--- a/src/platform/Platform.js
+++ b/src/platform/Platform.js
@@ -506,6 +506,7 @@ export default class Platform extends Observable {
      * @param {object} [query]
      * @param {object} [options]
      * @param {object} [options.headers]
+     * @param {boolean} [options.batch]
      * @param {boolean} [options.skipAuthCheck]
      * @return {Promise<ApiResponse>}
      */
@@ -515,6 +516,7 @@ export default class Platform extends Observable {
         options.url = url;
         options.query = query;
         options.body = body;
+        options.batch = !!options.batch;
         return await this.send(options);
     }
 


### PR DESCRIPTION
Hi Kirill,

Currently we have to manually construct the body for Batch PUT in Integration projects. But it's better that our SDK can provide a more convenient way to do that, which will save our developers' time.

So I tried.

Usage
```javascript
var url = '/account/~/extension/~/message-store/401654758008,401642088008';
var body = [{ body: { readStatus: 'Read'}}, { body: { readStatus: 'Read'}}];
platform.put(url, body, query, { batch: true });
```

Thanks,
Tom




