### PR TITLE
Default redirectUri option when instantiating SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ var rcsdk = new RingCentral.SDK({
     //server: 'https://platform.ringcentral.com', // PRODUCTION
     appKey: 'yourAppKey',
     appSecret: 'yourAppSecret'
+    //redirectUri: '' // optional
 });
 ```
 

--- a/src/SDK.js
+++ b/src/SDK.js
@@ -66,7 +66,8 @@ class SDK {
             options.appSecret,
             options.appName,
             options.appVersion,
-            SDK.version
+            SDK.version,
+            options.redirectUri
         );
 
         this._pubnubFactory = options.pubnubFactory || Externals.PUBNUB;

--- a/src/SDK.js
+++ b/src/SDK.js
@@ -41,6 +41,7 @@ class SDK {
      * @param {string} [options.appVersion]
      * @param {string} [options.pubnubFactory]
      * @param {string} [options.client]
+     * @param {string} [options.redirectUri]
      */
     constructor(options) {
 

--- a/src/platform/Platform.js
+++ b/src/platform/Platform.js
@@ -26,7 +26,7 @@ export default class Platform extends EventEmitter {
         logoutError: 'logoutError'
     };
 
-    constructor(client, cache, server, appKey, appSecret, appName, appVersion, sdkVersion) {
+    constructor(client, cache, server, appKey, appSecret, appName, appVersion, sdkVersion, redirectUri) {
 
         super();
 
@@ -47,6 +47,8 @@ export default class Platform extends EventEmitter {
 
         this._userAgent = (appName ? (appName + (appVersion ? '/' + appVersion : '')) + ' ' : '') +
                           'RCJSSDK/' + sdkVersion;
+
+        this._redirectUri = redirectUri || '';
 
     }
 
@@ -110,7 +112,7 @@ export default class Platform extends EventEmitter {
 
         return this.createUrl(Platform._authorizeEndpoint + '?' + queryStringify({
                 'response_type': 'code',
-                'redirect_uri': options.redirectUri || '',
+                'redirect_uri': options.redirectUri || this._redirectUri,
                 'client_id': this._appKey,
                 'state': options.state || '',
                 'brand_id': options.brandId || '',
@@ -261,7 +263,7 @@ export default class Platform extends EventEmitter {
 
                 body.grant_type = 'authorization_code';
                 body.code = options.code;
-                body.redirect_uri = options.redirectUri;
+                body.redirect_uri = options.redirectUri || this._redirectUri;
                 //body.client_id = this.getCredentials().key; // not needed
 
             }


### PR DESCRIPTION
This backwards-compatible change gives the end developer the option to specify a default redirectUri when instantiating the SDK object. The default redirectUri parameter will be used by loginUrl() and login() if another redirectUri is not explicitly specified in the arguments to those functions. This behavior is consistent with many other OAuth2 wrappers generally.

This PR should close #10 since this change provides an explicit workaround that should be noted in the documentation, and it is no longer implied that the redirectUri value should follow from loginUrl() to login(). Additionally, it is no longer necessary to explicitly declare the redirectUri in each of these functions if this option is specified at instantiation.