### PR TITLE
Check that login window opens

### DIFF
--- a/src/platform/Platform.js
+++ b/src/platform/Platform.js
@@ -249,6 +249,10 @@ Platform.prototype.loginWindow = function(options) {
         var top = ((height / 2) - (options.height / 2)) + dualScreenTop;
         var win = window.open(options.url, '_blank', (options.target == '_blank') ? 'scrollbars=yes, status=yes, width=' + options.width + ', height=' + options.height + ', left=' + left + ', top=' + top : '');
 
+        if(!win) {
+            throw new Error('Could not open login window. Please allow popups for this site');
+        }
+
         if (win.focus) win.focus();
 
         var eventMethod = window.addEventListener ? 'addEventListener' : 'attachEvent';


### PR DESCRIPTION
In Chrome, if a popup such as the authorization window is blocked, `window.open()` returns null. Because of this, the line `if(win.focus)` will cause the user to see an alert with the message: "Cannot read property 'focus' of null" This message is cryptic for most users, so this PR replaces that message with one that they will hopefully understand. Feel free to change the copy or provide some alternative functionality to help guide the user.