### PR TITLE
restore pubnub when network is back online

### DIFF
--- a/demo/core.html
+++ b/demo/core.html
@@ -100,6 +100,16 @@
                 subscription.on(subscription.events.notification, function(msg) {
                     cb(msg.body);
                 });
+                subscription.on(subscription.events.renewError, function() {
+                    subscription.reset();
+                    subscription = null;
+                    getPresenceSubscription(event, cb);
+                });
+                subscription.on(subscription.events.subscribeError, function() {
+                    subscription.reset();
+                    subscription = null;
+                    getPresenceSubscription(event, cb);
+                });
 
                 subscription
                     .restore([event])

--- a/src/subscription/Subscription.js
+++ b/src/subscription/Subscription.js
@@ -212,7 +212,8 @@ Subscription.prototype.subscribe = function() {
     }.bind(this)).catch(function(e) {
 
         e = this._platform.client().makeError(e);
-
+        // `reset` will remove pubnub instance.
+        // so if network is broken a long time, pubnub will be removed. And client can not receive notification anymore.
         this.reset()
             .emit(this.events.subscribeError, e);
 
@@ -251,7 +252,8 @@ Subscription.prototype.renew = function() {
     }.bind(this)).catch(function(e) {
 
         e = this._platform.client().makeError(e);
-
+        // `reset` will remove pubnub instance.
+        // so if network is broken a long time, pubnub will be removed. And client can not receive notification anymore.
         this.reset()
             .emit(this.events.renewError, e);
 
@@ -450,6 +452,7 @@ Subscription.prototype._subscribeAtPubnub = function() {
 
         this._pubnub = new PubNub({
             ssl: true,
+            restore: true,
             subscribeKey: deliveryMode.subscriberKey
         });
 

--- a/src/subscription/Subscription.js
+++ b/src/subscription/Subscription.js
@@ -213,7 +213,7 @@ Subscription.prototype.subscribe = function() {
 
         e = this._platform.client().makeError(e);
         // `reset` will remove pubnub instance.
-        // so if network is broken a long time, pubnub will be removed. And client can not receive notification anymore.
+        // so if network is broken for a long time, pubnub will be removed. And client can not receive notification anymore.
         this.reset()
             .emit(this.events.subscribeError, e);
 
@@ -253,7 +253,7 @@ Subscription.prototype.renew = function() {
 
         e = this._platform.client().makeError(e);
         // `reset` will remove pubnub instance.
-        // so if network is broken a long time, pubnub will be removed. And client can not receive notification anymore.
+        // so if network is broken for a long time, pubnub will be removed. And client can not receive notification anymore.
         this.reset()
             .emit(this.events.renewError, e);
 


### PR DESCRIPTION
For issue #79 
Set restore when pubnub is created to allow reconnect when network is back online.

If network is broken for a long time, SDK will try to renew subscription.  It will trigger a renew error, and SDK will remove pubnub instance to cause a unrecoverable disconnection. 
So it requires a resubscription when renew error or subscribe error happens.