### PR TITLE
Recreate Request object on request retry

### DIFF
--- a/src/platform/Platform.js
+++ b/src/platform/Platform.js
@@ -569,7 +569,7 @@ Platform.prototype.sendRequest = function(request, options) {
         }
 
         return this.delay(retryAfter).then(function() {
-            return this.sendRequest(request, options);
+            return this.sendRequest(this._client.createRequest(options), options);
         }.bind(this));
 
     }.bind(this));


### PR DESCRIPTION
Simple GET requests can be re-launched without any problem, but request will not be sent, if we are trying to utilize previous Request object and it includes Body. We will get uncaught TypeError
`Failed to execute 'fetch' on 'Window': Cannot construct a Request with a Request object that has already been used.`. Looks like, in accordance with Fetch API, Body is a one-use object and cannot be used for request again.

So we need to re-create Request object on sendRequest retry.