### PR TITLE
Access and Refresh Token time to live

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,10 +985,10 @@ var FormData = require('form-data'),
     formData = new FormData();
 
 // This is the mandatory part, the name and type should always be as follows
-formData.append('json', new Buffer(JSON.stringify(body)), {filename: 'request.json', contentType: 'application/json'});
+formData.append('json', Buffer(JSON.stringify(body)), {filename: 'request.json', contentType: 'application/json'});
 
 // To send a plain text
-formData.append('attachment', new Buffer('some plain text'), {filename: 'text.txt', contentType: 'text/plain'});
+formData.append('attachment', Buffer('some plain text'), {filename: 'text.txt', contentType: 'text/plain'});
 
 // To send a file from file system
 formData.append('attachment', require('fs').createReadStream('/foo/bar.jpg'));

--- a/src/platform/Platform.js
+++ b/src/platform/Platform.js
@@ -358,8 +358,8 @@ Platform.prototype.login = function(options) {
         }
 
         if (options.endpointId) body.endpoint_id = options.endpointId;
-        if (options.accessTokenTtl) body.accessTokenTtl = options.accessTokenTtl;
-        if (options.refreshTokenTtl) body.refreshTokenTtl = options.refreshTokenTtl;
+        if (options.accessTokenTtl) body.access_token_ttl = options.accessTokenTtl;
+        if (options.refreshTokenTtl) body.refresh_token_ttl = options.refreshTokenTtl;
 
         resolve(this._tokenRequest(Platform._tokenEndpoint, body));
 


### PR DESCRIPTION
Was working on a customer account that needed to have the refresh_token_ttl set to 0 for their users.

Spun my wheels for a while, but then realized the form-data in the login request wasn't using the correct format required by RC for setting ttl. 

For example: 
```body.accessTokenTtl``` should be ```body.access_token_ttl```