### PR TITLE
feat(SDK): add patch method for skd

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -355,6 +355,7 @@ If your `Promise` library supports global error handler it might be useful to lo
 rcsdk.get('/restapi/v1.0/account/~/extension/~', {...query}).then(...);
 rcsdk.post('/restapi/v1.0/account/~/extension/~', {...body}, {...query}).then(...);
 rcsdk.put('/restapi/v1.0/account/~/extension/~', {...body}, {...query}).then(...);
+rcsdk.patch('/restapi/v1.0/account/~/extension/~', {...body}, {...query}).then(...);
 rcsdk.delete('/restapi/v1.0/account/~/extension/~', {...query}).then(...);
 ```
 

--- a/sdk/src/SDK.ts
+++ b/sdk/src/SDK.ts
@@ -110,6 +110,10 @@ export class SDK {
         this.platform().send({method: 'PUT', url, query, body, ...options});
 
     /* istanbul ignore next */
+    public patch = async (url, body?, query?, options?: SendOptions): Promise<Response> =>
+        this.platform().send({method: 'PATCH', url, query, body, ...options});
+
+    /* istanbul ignore next */
     public delete = async (url, query?, options?: SendOptions): Promise<Response> =>
         this.platform().send({method: 'DELETE', url, query, ...options});
 

--- a/sdk/src/platform/Platform-spec.ts
+++ b/sdk/src/platform/Platform-spec.ts
@@ -319,7 +319,7 @@ describe('RingCentral.platform.Platform', () => {
         );
     });
 
-    describe('get, post, put, delete', () => {
+    describe('get, post, put, patch, delete', () => {
         it(
             'sends request using appropriate method',
             asyncTest(async sdk => {
@@ -337,6 +337,7 @@ describe('RingCentral.platform.Platform', () => {
                 await test('get');
                 await test('post');
                 await test('put');
+                await test('patch');
                 await test('delete');
             }),
         );

--- a/sdk/src/platform/Platform.ts
+++ b/sdk/src/platform/Platform.ts
@@ -500,6 +500,10 @@ export default class Platform extends EventEmitter {
         return this.send({method: 'PUT', url, query, body, ...options});
     }
 
+    public async patch(url, body?, query?, options?: SendOptions): Promise<Response> {
+        return this.send({method: 'PATCH', url, query, body, ...options});
+    }
+
     public async delete(url, query?, options?: SendOptions): Promise<Response> {
         return this.send({method: 'DELETE', url, query, ...options});
     }


### PR DESCRIPTION
PATCH method was a common method in RESTful API but not support in SDK.

This pr is for add **PATCH** method to SDK.