### PR TITLE
Handle rate limit for all send requests

### DIFF
--- a/sdk/src/SDK-spec.ts
+++ b/sdk/src/SDK-spec.ts
@@ -25,6 +25,11 @@ describe('RingCentral.SDK', () => {
         return test(this, SDK.server.production);
     });
 
+    it('sets rate limit', async function rateLimitTest() {
+        const sdk = new SDK({handleRateLimit: 60});
+        expect(sdk.platform()['_handleRateLimit']).to.equal(60);
+    });
+
     describe('handleLoginRedirect', () => {
         const sdk = new SDK();
 

--- a/sdk/src/SDK.ts
+++ b/sdk/src/SDK.ts
@@ -57,7 +57,7 @@ export class SDK {
     }
 
     public constructor(options: SDKOptions = {}) {
-        const {cachePrefix, defaultRequestInit} = options;
+        const {cachePrefix, defaultRequestInit, handleRateLimit} = options;
 
         this._externals = new Externals({
             ...defaultExternals,
@@ -79,6 +79,7 @@ export class SDK {
             externals: this._externals,
             client: this._client,
             cache: this._cache,
+            handleRateLimit
         });
     }
 
@@ -164,6 +165,7 @@ export class SDK {
 export interface SDKOptions extends PlatformOptions, ExternalsOptions {
     cachePrefix?: string;
     defaultRequestInit?: CreateRequestOptions;
+    handleRateLimit?: boolean
 }
 
 export default SDK;

--- a/sdk/src/SDK.ts
+++ b/sdk/src/SDK.ts
@@ -79,7 +79,7 @@ export class SDK {
             externals: this._externals,
             client: this._client,
             cache: this._cache,
-            handleRateLimit
+            handleRateLimit,
         });
     }
 
@@ -165,7 +165,7 @@ export class SDK {
 export interface SDKOptions extends PlatformOptions, ExternalsOptions {
     cachePrefix?: string;
     defaultRequestInit?: CreateRequestOptions;
-    handleRateLimit?: boolean
+    handleRateLimit?: boolean | number;
 }
 
 export default SDK;

--- a/sdk/src/platform/Platform.ts
+++ b/sdk/src/platform/Platform.ts
@@ -69,6 +69,8 @@ export default class Platform extends EventEmitter {
 
     private _urlPrefix;
 
+    private _handleRateLimit: boolean
+
     public constructor({
         server,
         clientId,
@@ -87,6 +89,7 @@ export default class Platform extends EventEmitter {
         authorizeEndpoint = '/restapi/oauth/authorize',
         authProxy = false,
         urlPrefix = '',
+        handleRateLimit
     }: PlatformOptionsConstructor) {
         super();
 
@@ -114,6 +117,7 @@ export default class Platform extends EventEmitter {
         this._tokenEndpoint = tokenEndpoint;
         this._revokeEndpoint = revokeEndpoint;
         this._authorizeEndpoint = authorizeEndpoint;
+        this._handleRateLimit = handleRateLimit;
     }
 
     public on(event: events.beforeLogin, listener: () => void);
@@ -464,7 +468,7 @@ export default class Platform extends EventEmitter {
 
             if (status === Client._rateLimitStatus) {
                 const defaultRetryAfter =
-                    !handleRateLimit || typeof handleRateLimit === 'boolean' ? 60 : handleRateLimit;
+                    !handleRateLimit || typeof handleRateLimit === 'boolean' || this._handleRateLimit === true ? 60 : handleRateLimit;
 
                 // FIXME retry-after is custom header, by default, it can't be retrieved. Server should add header: 'Access-Control-Expose-Headers: retry-after'.
                 retryAfter = parseFloat(response.headers.get('retry-after') || defaultRetryAfter) * 1000;
@@ -554,6 +558,7 @@ export interface PlatformOptions extends AuthOptions {
     authorizeEndpoint?: string;
     authProxy?: boolean;
     urlPrefix?: string;
+    handleRateLimit?: boolean;
 }
 
 export interface PlatformOptionsConstructor extends PlatformOptions {

--- a/sdk/src/platform/Platform.ts
+++ b/sdk/src/platform/Platform.ts
@@ -428,6 +428,10 @@ export default class Platform extends EventEmitter {
     }
 
     public async inflateRequest(request: Request, options: SendOptions = {}): Promise<Request> {
+        if (this._handleRateLimit) {
+            options.handleRateLimit = this._handleRateLimit;
+        }
+
         options = options || {};
 
         request.headers.set('X-User-Agent', this._userAgent);
@@ -454,10 +458,6 @@ export default class Platform extends EventEmitter {
 
             const {response} = e;
             const {status} = response;
-
-            if (this._handleRateLimit) {
-                options.handleRateLimit = this._handleRateLimit;
-            }
 
             if ((status !== Client._unauthorizedStatus && status !== Client._rateLimitStatus) || this._authProxy)
                 throw e;

--- a/sdk/src/platform/Platform.ts
+++ b/sdk/src/platform/Platform.ts
@@ -428,11 +428,11 @@ export default class Platform extends EventEmitter {
     }
 
     public async inflateRequest(request: Request, options: SendOptions = {}): Promise<Request> {
+        options = options || {};
+
         if (this._handleRateLimit) {
             options.handleRateLimit = this._handleRateLimit;
         }
-
-        options = options || {};
 
         request.headers.set('X-User-Agent', this._userAgent);
 

--- a/sdk/src/platform/Platform.ts
+++ b/sdk/src/platform/Platform.ts
@@ -69,7 +69,7 @@ export default class Platform extends EventEmitter {
 
     private _urlPrefix;
 
-    private _handleRateLimit: boolean
+    private _handleRateLimit: boolean;
 
     public constructor({
         server,
@@ -89,7 +89,7 @@ export default class Platform extends EventEmitter {
         authorizeEndpoint = '/restapi/oauth/authorize',
         authProxy = false,
         urlPrefix = '',
-        handleRateLimit
+        handleRateLimit,
     }: PlatformOptionsConstructor) {
         super();
 
@@ -455,6 +455,10 @@ export default class Platform extends EventEmitter {
             const {response} = e;
             const {status} = response;
 
+            if (this._handleRateLimit) {
+                options.handleRateLimit = this._handleRateLimit;
+            }
+
             if ((status !== Client._unauthorizedStatus && status !== Client._rateLimitStatus) || this._authProxy)
                 throw e;
 
@@ -468,7 +472,7 @@ export default class Platform extends EventEmitter {
 
             if (status === Client._rateLimitStatus) {
                 const defaultRetryAfter =
-                    !handleRateLimit || typeof handleRateLimit === 'boolean' || this._handleRateLimit === true ? 60 : handleRateLimit;
+                    !handleRateLimit || typeof handleRateLimit === 'boolean' ? 60 : handleRateLimit;
 
                 // FIXME retry-after is custom header, by default, it can't be retrieved. Server should add header: 'Access-Control-Expose-Headers: retry-after'.
                 retryAfter = parseFloat(response.headers.get('retry-after') || defaultRetryAfter) * 1000;

--- a/sdk/src/test/test.ts
+++ b/sdk/src/test/test.ts
@@ -70,6 +70,7 @@ export function createSdk(options: SDKOptions = {}) {
         fetch: fetchMock.fetchHandler,
         refreshDelayMs: 1,
         redirectUri: 'http://foo',
+        handleRateLimit: false,
         ...options,
     });
 }


### PR DESCRIPTION
Added `handleRateLimit` bool variable to SDK constructor. It gets passed down to Platform, and is then used in all send requests. 

It's optional, and will allow the developers to still send `handleRateLimit` as an option to an individual request. 