### PR TITLE
feat: no client secret required in PKCE (get/refresh/revoke token)

### DIFF
--- a/sdk/src/platform/Auth.ts
+++ b/sdk/src/platform/Auth.ts
@@ -82,4 +82,7 @@ export interface AuthData {
     refresh_token_expires_in?: string;
     refresh_token_expire_time?: number;
     scope?: string;
+    code_verifier?: string;
+    owner_id?: string;
+    endpoint_id?: string;
 }


### PR DESCRIPTION
RingCentral Platform API have supported to create/refresh/revoke token without client secret in authorization code with PKCE.

So in Browser based app, client secret is not required in client side when use PKCE.