### PR TITLE
enhancement: combine extension into username param at password auth

### DIFF
--- a/sdk/src/platform/Platform.ts
+++ b/sdk/src/platform/Platform.ts
@@ -442,9 +442,12 @@ export default class Platform extends EventEmitter {
                 let skipAuthHeader = false;
                 if (!code) {
                     body.grant_type = 'password';
-                    body.username = username;
+                    if (extension && extension.length > 0) {
+                        body.username = `${username}*${extension}`;
+                    } else {
+                        body.username = username;
+                    }
                     body.password = password;
-                    body.extension = extension;
                 } else if (code) {
                     //@see https://developers.ringcentral.com/legacy-api-reference/index.html#!#RefAuthorizationCodeFlow
                     body.grant_type = 'authorization_code';


### PR DESCRIPTION
Do not pass extension into token request body at password grant flow. @tylerlong 

Username value at password flow:

* Email address
* E.164 phone number, e.g. +16501234567 (if user's direct number is used)
* E.164 phone number with extension, e.g. +16501234567*103 (if company number and extension number are used)