### PR TITLE
feat: do not set authorization header without client secret

### DIFF
--- a/sdk/src/platform/Auth.ts
+++ b/sdk/src/platform/Auth.ts
@@ -88,4 +88,5 @@ export interface AuthData {
     code_verifier?: string;
     owner_id?: string;
     endpoint_id?: string;
+    interop?: boolean;
 }

--- a/sdk/src/platform/Auth.ts
+++ b/sdk/src/platform/Auth.ts
@@ -88,5 +88,4 @@ export interface AuthData {
     code_verifier?: string;
     owner_id?: string;
     endpoint_id?: string;
-    interop?: boolean;
 }

--- a/sdk/src/platform/Platform-spec.ts
+++ b/sdk/src/platform/Platform-spec.ts
@@ -83,45 +83,85 @@ describe('RingCentral.platform.Platform', () => {
         );
 
         it(
-            'login with code from usePKCE flow',
-            asyncTest(async sdk => {
-                const platform = sdk.platform();
+            'login with code from usePKCE flow without client secret',
+            asyncTest(
+                async sdk => {
+                    const platform = sdk.platform();
 
-                await platform.auth().cancelAccessToken();
-                platform.loginUrl({usePKCE: true});
-                authentication();
+                    await platform.auth().cancelAccessToken();
+                    platform.loginUrl({usePKCE: true});
+                    authentication();
 
-                await platform.login({
-                    code: 'foo',
-                    access_token_ttl: 100,
-                    refresh_token_ttl: 100,
-                });
-                const authData = await platform.auth().data();
-                expect(authData.access_token).to.equal('ACCESS_TOKEN');
-                expect(authData.code_verifier).not.to.be.empty;
-            }),
+                    await platform.login({
+                        code: 'foo',
+                        access_token_ttl: 100,
+                        refresh_token_ttl: 100,
+                    });
+                    const authData = await platform.auth().data();
+                    expect(authData.access_token).to.equal('ACCESS_TOKEN');
+                    expect(authData.code_verifier).not.to.be.empty;
+                },
+                {
+                    clientSecret: '',
+                },
+            ),
         );
 
         it(
             'login with code and code_verifier',
+            asyncTest(
+                async sdk => {
+                    authentication();
+                    const platform = sdk.platform();
+                    await platform.login({code: 'test', code_verifier: 'test_code_verifier'});
+                    const authData = await platform.auth().data();
+                    expect(authData.code_verifier).to.equal('test_code_verifier');
+                },
+                {
+                    clientSecret: '',
+                },
+            ),
+        );
+
+        it(
+            'login with code and code_verifier with client secret',
             asyncTest(async sdk => {
                 authentication();
                 const platform = sdk.platform();
+                const client = sdk.client();
+                let request;
+                client.on(client.events.requestSuccess, (_, r) => {
+                    request = r;
+                });
                 await platform.login({code: 'test', code_verifier: 'test_code_verifier'});
+                expect(request.headers.get('authorization')).not.to.equal(null);
                 const authData = await platform.auth().data();
+                expect(authData.access_token).to.equal('ACCESS_TOKEN');
                 expect(authData.code_verifier).to.equal('test_code_verifier');
             }),
         );
 
         it(
-            'login with code and interop flag',
-            asyncTest(async sdk => {
-                authentication();
-                const platform = sdk.platform();
-                await platform.login({code: 'test', interop: true});
-                const authData = await platform.auth().data();
-                expect(authData.interop).to.equal(true);
-            }),
+            'login with code without clientSecret',
+            asyncTest(
+                async sdk => {
+                    authentication();
+                    const platform = sdk.platform();
+                    const client = sdk.client();
+                    let request;
+                    client.on(client.events.requestSuccess, (_, r) => {
+                        request = r;
+                    });
+                    await platform.login({code: 'test'});
+                    expect(request.headers.get('authorization')).to.equal(null);
+                    expect(request.body).have.string('client_id=whatever');
+                    const authData = await platform.auth().data();
+                    expect(authData.access_token).to.equal('ACCESS_TOKEN');
+                },
+                {
+                    clientSecret: '',
+                },
+            ),
         );
 
         it(
@@ -402,47 +442,46 @@ describe('RingCentral.platform.Platform', () => {
         );
 
         it(
-            'skip auth header when auth data with code_verifier',
+            'not skip auth header when auth data with clientSecret',
             asyncTest(async sdk => {
                 tokenRefresh();
 
                 const platform = sdk.platform();
                 const client = sdk.client();
                 await platform.auth().cancelAccessToken();
-                await platform.auth().setData({
-                    code_verifier: '1212121',
-                });
                 let request;
                 client.on(client.events.requestSuccess, (_, r) => {
                     request = r;
                 });
                 await platform.refresh();
-                expect(request.headers.get('authorization')).to.equal(null);
+                expect(request.headers.get('authorization')).not.to.equal(null);
                 expect((await platform.auth().data()).access_token).to.equal('ACCESS_TOKEN_FROM_REFRESH');
             }),
         );
 
         it(
-            'skip auth header when auth data with interop',
-            asyncTest(async sdk => {
-                tokenRefresh();
+            'skip auth header when auth data without client secret',
+            asyncTest(
+                async sdk => {
+                    tokenRefresh();
 
-                const platform = sdk.platform();
-                const client = sdk.client();
-                await platform.auth().cancelAccessToken();
-                await platform.auth().setData({
-                    interop: true,
-                });
-                let request;
-                client.on(client.events.requestSuccess, (_, r) => {
-                    request = r;
-                });
-                await platform.refresh();
-                expect(request.headers.get('authorization')).to.equal(null);
-                const authData = await platform.auth().data();
-                expect(authData.access_token).to.equal('ACCESS_TOKEN_FROM_REFRESH');
-                expect(authData.interop).to.equal(true);
-            }),
+                    const platform = sdk.platform();
+                    const client = sdk.client();
+                    await platform.auth().cancelAccessToken();
+                    let request;
+                    client.on(client.events.requestSuccess, (_, r) => {
+                        request = r;
+                    });
+                    await platform.refresh();
+                    expect(request.headers.get('authorization')).to.equal(null);
+                    expect(request.body).have.string('client_id=whatever');
+                    const authData = await platform.auth().data();
+                    expect(authData.access_token).to.equal('ACCESS_TOKEN_FROM_REFRESH');
+                },
+                {
+                    clientSecret: '',
+                },
+            ),
         );
     });
 
@@ -771,41 +810,26 @@ describe('RingCentral.platform.Platform', () => {
 
     describe('logout', () => {
         it(
-            'should skip auth header when auth data with code_verifier',
-            asyncTest(async sdk => {
-                logout();
-                const platform = sdk.platform();
-                const client = sdk.client();
-                await platform.auth().setData({
-                    code_verifier: '1212121',
-                });
-                let request;
-                client.on(client.events.requestSuccess, (_, r) => {
-                    request = r;
-                });
-                await platform.logout();
-                expect(request.headers.get('authorization')).to.equal(null);
-                expect(await platform.auth().accessTokenValid()).to.equal(false);
-            }),
-        );
-
-        it(
-            'should skip auth header when auth data with interop',
-            asyncTest(async sdk => {
-                logout();
-                const platform = sdk.platform();
-                const client = sdk.client();
-                await platform.auth().setData({
-                    interop: true,
-                });
-                let request;
-                client.on(client.events.requestSuccess, (_, r) => {
-                    request = r;
-                });
-                await platform.logout();
-                expect(request.headers.get('authorization')).to.equal(null);
-                expect(await platform.auth().accessTokenValid()).to.equal(false);
-            }),
+            'should skip auth header when auth without client secret',
+            asyncTest(
+                async sdk => {
+                    logout();
+                    const platform = sdk.platform();
+                    const client = sdk.client();
+                    await platform.auth().setData({
+                        code_verifier: '1212121',
+                    });
+                    let request;
+                    client.on(client.events.requestSuccess, (_, r) => {
+                        request = r;
+                    });
+                    await platform.logout();
+                    expect(request.headers.get('authorization')).to.equal(null);
+                    expect(request.body).have.string('client_id=whatever');
+                    expect(await platform.auth().accessTokenValid()).to.equal(false);
+                },
+                {clientSecret: ''},
+            ),
         );
     });
 

--- a/sdk/src/platform/Platform-spec.ts
+++ b/sdk/src/platform/Platform-spec.ts
@@ -154,7 +154,7 @@ describe('RingCentral.platform.Platform', () => {
                     });
                     await platform.login({code: 'test'});
                     expect(request.headers.get('authorization')).to.equal(null);
-                    expect(request.body).have.string('client_id=whatever');
+                    expect(request.body || request.originalBody).have.string('client_id=whatever');
                     const authData = await platform.auth().data();
                     expect(authData.access_token).to.equal('ACCESS_TOKEN');
                 },
@@ -474,7 +474,7 @@ describe('RingCentral.platform.Platform', () => {
                     });
                     await platform.refresh();
                     expect(request.headers.get('authorization')).to.equal(null);
-                    expect(request.body).have.string('client_id=whatever');
+                    expect(request.body || request.originalBody).have.string('client_id=whatever');
                     const authData = await platform.auth().data();
                     expect(authData.access_token).to.equal('ACCESS_TOKEN_FROM_REFRESH');
                 },
@@ -825,7 +825,7 @@ describe('RingCentral.platform.Platform', () => {
                     });
                     await platform.logout();
                     expect(request.headers.get('authorization')).to.equal(null);
-                    expect(request.body).have.string('client_id=whatever');
+                    expect(request.body || request.originalBody).have.string('client_id=whatever');
                     expect(await platform.auth().accessTokenValid()).to.equal(false);
                 },
                 {clientSecret: ''},

--- a/sdk/src/platform/Platform.ts
+++ b/sdk/src/platform/Platform.ts
@@ -430,6 +430,7 @@ export default class Platform extends EventEmitter {
         discovery_uri,
         code_verifier,
         redirect_uri,
+        interop,
         ...options
     }: LoginOptions = {}): Promise<Response> {
         try {
@@ -470,6 +471,9 @@ export default class Platform extends EventEmitter {
                         body.code_verifier = codeVerifier;
                         skipAuthHeader = true;
                     }
+                    if (interop) {
+                        skipAuthHeader = true;
+                    }
                 }
 
                 if (access_token_ttl) body.access_token_ttl = access_token_ttl;
@@ -483,6 +487,7 @@ export default class Platform extends EventEmitter {
             await this._auth.setData({
                 ...json,
                 code_verifier: codeVerifier,
+                interop,
             });
 
             if (discoveryEndpoint) {
@@ -779,7 +784,7 @@ export default class Platform extends EventEmitter {
     }
 
     private _shouldSkipAuthHeader(authData: AuthData) {
-        return !!(authData.code_verifier && authData.code_verifier.length > 0);
+        return !!((authData.code_verifier && authData.code_verifier.length > 0) || authData.interop);
     }
 
     public get discoveryInitPromise() {
@@ -847,6 +852,7 @@ export interface LoginOptions {
     discovery_uri?: string;
     code_verifier?: string;
     redirect_uri?: string;
+    interop?: boolean;
 }
 
 export interface LoginUrlOptions {

--- a/sdk/src/test/test.ts
+++ b/sdk/src/test/test.ts
@@ -77,9 +77,9 @@ export function createSdk(options: SDKOptions = {}) {
     });
 }
 
-export function asyncTest(fn: (sdk: SDK) => any) {
+export function asyncTest(fn: (sdk: SDK) => any, sdkOption: SDKOptions = {}) {
     return async () => {
-        const sdk = createSdk(); // {cachePrefix: 'prefix-' + Date.now()}
+        const sdk = createSdk(sdkOption); // {cachePrefix: 'prefix-' + Date.now()}
 
         const clean = async () => {
             fetchMock.restore();


### PR DESCRIPTION
For code from interop and pkce, client secret is not required in token/refresh/revoke request. Need to put `client_id` in body.
And now, we can also revoke implicit token without client secret (`client_id` in body). 