### PR TITLE
Add message in readme for v3 informing the package has been renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![Community](https://img.shields.io/badge/dynamic/json.svg?label=community&colorB=&suffix=%20users&query=$.approximate_people_count&uri=http%3A%2F%2Fapi.getsatisfaction.com%2Fcompanies%2F102909.json)](https://devcommunity.ringcentral.com/ringcentraldev)
 [![Twitter](https://img.shields.io/twitter/follow/ringcentraldevs.svg?style=social&label=follow)](https://twitter.com/RingCentralDevs)
 
+> #### This package has now been renamed to [@ringcentral/sdk](https://www.npmjs.com/package/@ringcentral/sdk).
+> #### Kindly use the new package for the latest version of the sdk
+\
 __[RingCentral Developers](https://developer.ringcentral.com/api-products)__ is a cloud communications platform which can be accessed via more than 70 APIs. The platform's main capabilities include technologies that enable:
 __[Voice](https://developer.ringcentral.com/api-products/voice), [SMS/MMS](https://developer.ringcentral.com/api-products/sms), [Fax](https://developer.ringcentral.com/api-products/fax), [Glip Team Messaging](https://developer.ringcentral.com/api-products/team-messaging), [Data and Configurations](https://developer.ringcentral.com/api-products/configuration)__.
 


### PR DESCRIPTION
The readme of v3 does not inform that the package has been renamed and moved under another repo at npm causing confusion.
Adding a message in v3 redirecting users to @ringcentral/sdk whenever someone stumbles upon v3