### PR TITLE
docs fix: binary downloads as stream

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -393,7 +393,7 @@ rcsdk.get('/restapi/v1.0/account/~/messages/foo/content').then(function(res) {
 // read as stream
 rcsdk.get('/restapi/v1.0/account/~/messages/foo/content').then(function(res) {
 
-    res.response().body.pipe(fs.createWriteStream('./octocat.png')); // we are accessing Node Fetch's Response
+    res.body.pipe(fs.createWriteStream('./octocat.png')); // we are accessing Node Fetch's Response
 
 });
 ```


### PR DESCRIPTION
Empirically found that in 4.x (I used 4.6.1), the means to obtain a stream for a binary download is: `res.body`