### PR TITLE
[FIX] Resolve "Buffer is undefined" Error in Webpack Configuration

### DIFF
--- a/utils/webpack.js
+++ b/utils/webpack.js
@@ -1,4 +1,6 @@
-function createConfig({entry, filename, outputPath, libraryName, externals}) {
+const webpack = require('webpack');
+
+function createConfig({ entry, filename, outputPath, libraryName, externals }) {
     const common = {
         mode: 'production',
         devtool: 'source-map',
@@ -12,6 +14,16 @@ function createConfig({entry, filename, outputPath, libraryName, externals}) {
                 },
             ],
         },
+        plugins: [
+            // Workaround for Buffer is undefined:
+            new webpack.ProvidePlugin({
+                Buffer: ['buffer', 'Buffer'],
+            }),
+            // Workaround for process is undefined:
+            new webpack.ProvidePlugin({
+                process: 'process/browser',
+            }),
+        ],
         resolve: {
             extensions: ['.tsx', '.ts', '.js'],
             fallback: {


### PR DESCRIPTION
### Description:
This merge request addresses the "Buffer is undefined" error encountered during the Webpack build process. The issue was caused by Webpack 5 no longer including polyfills by default. The following changes have been made:

- Added `Buffer` polyfill using `ProvidePlugin` in Webpack configuration.
- Included `process/browser` polyfill to handle the `process` object in the browser.

### Impact:
These changes ensure that the project builds correctly with Webpack 5, avoiding runtime errors related to `Buffer` and `process`.
